### PR TITLE
smaller h1s

### DIFF
--- a/app/static/css/contribute/contribute.less
+++ b/app/static/css/contribute/contribute.less
@@ -183,7 +183,7 @@ main {
 .content {
     overflow: auto;
     h1 {
-        font-size: 64px;
+        font-size: 48px;
     }
 }
 .content-column {


### PR DESCRIPTION
@ossreleasefeed r?

I thought those `h1`s were screaming for too much attention. 
![screenshot 2014-10-16 10 44 53](https://cloud.githubusercontent.com/assets/26739/4667372/30a4ccee-555c-11e4-8c41-164aae0b9e52.png)
48px seems a better size. 
