### PR TITLE
Adding Mozilla Input to knownurls.txt

### DIFF
--- a/knownurls.txt
+++ b/knownurls.txt
@@ -5,3 +5,4 @@ https://developer.mozilla.org/contribute.json
 https://peekaboo.mozilla.org/contribute.json
 https://crash-stats.mozilla.com/contribute.json
 https://raw.githubusercontent.com/mozilla/buddyup/master/contribute.json
+https://input.mozilla.org/contribute.json


### PR DESCRIPTION
Mozilla Input's contribute.json file can be found at the link below;
https://input.mozilla.org/contribute.json
