### PR TITLE
Add Mozilla Reps to knownurls list.

### DIFF
--- a/knownurls.txt
+++ b/knownurls.txt
@@ -7,3 +7,4 @@ https://input.mozilla.org/contribute.json
 https://oneanddone.mozilla.org/contribute.json
 https://peekaboo.mozilla.org/contribute.json
 https://www.mozilla.org/contribute.json
+https://reps.mozilla.org/contribute.json


### PR DESCRIPTION
ReMo portal has now a contribute.json file [0].

[0] https://reps.mozilla.org/contribute.json
