### PR TITLE
participate->home not required, fixes #2

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -38,7 +38,6 @@
                 }
             },
             "required": [
-                "home",
                 "docs"
             ]
         },


### PR DESCRIPTION
@Osmose @pmclanahan r?

Note that the [Schema page](https://contribute.paas.allizom.org/schema) will pick this up by automatically reading [this url](https://raw.githubusercontent.com/mozilla/contribute.json/master/schema.json).