### PR TITLE
Fix #61: Add translate key to schema.

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -41,6 +41,32 @@
                 "docs"
             ]
         },
+        "translate": {
+            "type": "object",
+            "properties": {
+                "home": {
+                    "type": "string"
+                },
+                "docs": {
+                    "type": "string"
+                },
+                "mailing-list": {
+                    "type": "string"
+                },
+                "irc": {
+                    "type": "string"
+                },
+                "irc-contacts": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "docs"
+            ]
+        },
         "repository": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
This is my proposal to fix #61. I just coppied and renamed `participate`. I could easily see having something other than `docs` be the only required property, but whatever the group feels for that is fine with me.