### PR TITLE
SystemExit on URL downloads that take forever

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -127,7 +127,7 @@ class ValidationView(MethodView):
                     '/master/contribute.json'
                 )
             try:
-                response = requests.get(url)
+                response = requests.get(url, timeout=10)
                 content = response.json()
             except (ValueError, requests.exceptions.RequestException) as exp:
                 return jsonify({'request_error': str(exp)})


### PR DESCRIPTION
Fixes #96


Now you get this instead:
<img width="1181" alt="screen shot 2018-09-13 at 4 20 33 pm" src="https://user-images.githubusercontent.com/26739/45513565-ffc32780-b770-11e8-87a4-b0c2c2a0f107.png">
