### PR TITLE
correct raven install line

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,4 @@ redis==2.10.6
 requests[security]==2.20.0
 six==1.11.0
 whitenoise==4.0
-raven==6.9.0
-blinker==1.4
+raven[flask]==6.10.0


### PR DESCRIPTION
First of all, this is the correct way to add `raven` to the requirements file for Flask projects. 
Second of all, version 6.10.0 had some mention about fixes specifically to stackframes from Flask apps. Can't hurt. 