### PR TITLE
Add 'chat' to the 'participate' object

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,16 @@ as the subject. Previous discussion can be found in the comments of [the origina
             "jgmize",
             "malexis",
             "cmore"
-        ]
+        ],
+        "chat": {
+            "url": "irc://irc.mozilla.org/#www",
+            "contacts": [
+                "pmac",
+                "jgmize",
+                "malexis",
+                "cmore"
+            ]
+        }
     },
     "bugs": {
         "list": "https://bugzilla.mozilla.org/buglist.cgi?query_format=advanced&bug_status=UNCONFIRMED&bug_status=NEW&product=www.mozilla.org",

--- a/knownurls.txt
+++ b/knownurls.txt
@@ -16,3 +16,4 @@ https://raw.githubusercontent.com/mozilla/configman/master/contribute.json
 https://nightly.mozilla.org/contribute.json
 https://firefox.settings.services.mozilla.com/v1/contribute.json
 https://contrast-finder.org/contribute.json
+https://chat.mozilla.org/contribute.json

--- a/schema.json
+++ b/schema.json
@@ -35,6 +35,23 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "chat": {
+                  "type": "object",
+                  "properties": {
+                    "url": {
+                      "type": "string"
+                    },
+                    "contacts": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "url"
+                  ]
                 }
             },
             "required": [


### PR DESCRIPTION
The 'chat' object if given must supply an URL form
reference to a chat for the project. Optionally
it can also supply contacts in that chat.

I didn't add any examples except the IRC channel ref
that was already in the readme. I also didn't remove
the IRC keys. Possibly they could be removed immediately
since the spec is not guaranteed according to the readme
to be stable but possibly they should be removed only
after Observatory [supports the new chat key](https://infosec.mozilla.org/guidelines/web_security#contributejson) and Mozilla
sites have had time to roll over so they don't suffer a bad
Observatory rating?

Also add chat.mozilla.org contribute.json to the list.
Note currently it contains the IRC keys, since
Mozilla Observatory will otherwise give -5 points
until a Matrix chat room reference can be given to
point to the right Riot Web related room.

Closes #106 