### PR TITLE
Fix mismatch between repo LICENSE and contribute.json field

### DIFF
--- a/contribute.json
+++ b/contribute.json
@@ -3,7 +3,7 @@
     "description": "A JSON schema for open-source project contribution data.",
     "repository": {
         "url": "https://github.com/mozilla/contribute.json",
-        "license": "MPL2"
+        "license": "Apache-2.0"
     },
     "bugs": {
         "list": "https://github.com/mozilla/contribute.json/issues",


### PR DESCRIPTION
If the correct license is MPL-2.0, then let me know and I'll submit the opposite PR :)

Using the standard [SPDX identifier](https://spdx.org/licenses/) for the license name.